### PR TITLE
Bug/#71 - SPARQL client set disabled execute button

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "^5.2.4",
-    "@ngtools/webpack": "^1.9.8",
+    "@ngtools/webpack": "1.10.0",
     "@types/codemirror": "^0.0.55",
     "@types/jasmine": "^2.8.6",
     "@types/jasmine-ajax": "^3.1.37",

--- a/src/app/root-content/explorer/document-explorer/document-explorer.component.html
+++ b/src/app/root-content/explorer/document-explorer/document-explorer.component.html
@@ -29,10 +29,10 @@
 		                    (onRefreshDocument)="refreshDocument($event)"></cw-document-viewer>
 		<cw-document-creator #documentCreator
 		                     [parentURI]="selectedDocumentURI"
-		                     (onSuccess)="onSuccessAccessPoint($event)"></cw-document-creator>
+		                     (onSuccess)="onSuccessCreateDocument($event)"></cw-document-creator>
 		<cw-access-point-creator #accessPointCreator
 		                         [parentURI]="selectedDocumentURI"
-		                         (onSuccess)="onSuccessCreateDocument($event)"></cw-access-point-creator>
+		                         (onSuccess)="onSuccessAccessPoint($event)"></cw-access-point-creator>
 		<cw-document-deleter #documentDeleter
 		                     [documentURI]="selectedDocumentURI"
 		                     (onSuccess)="onSuccessDeleteDocument($event)"></cw-document-deleter>

--- a/src/app/root-content/sparql-client/sparql-client.component.ts
+++ b/src/app/root-content/sparql-client/sparql-client.component.ts
@@ -298,12 +298,12 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	 */
 	getSPARQLOperation( query:string ):string {
 		switch( true ) {
-			case (this.regExpSelect.test( query )):
-				return this.sparqlQueryOperations.select.name;
 			case (this.regExpConstruct.test( query )):
 				return this.sparqlQueryOperations.construct.name;
 			case (this.regExpAsk.test( query )):
 				return this.sparqlQueryOperations.ask.name;
+			case (this.regExpSelect.test( query )):
+				return this.sparqlQueryOperations.select.name;
 			case (this.regExpDescribe.test( query )):
 				return this.sparqlQueryOperations.describe.name;
 			case (this.regExpInsert.test( query )):

--- a/src/app/root-content/sparql-client/sparql-client.component.ts
+++ b/src/app/root-content/sparql-client/sparql-client.component.ts
@@ -234,6 +234,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 
 	ngOnInit():void {
 		this.isCarbonContext = true;
+		this.currentQuery.endpoint = this.carbon.baseURI;
 	}
 
 	ngAfterViewInit():void {
@@ -417,7 +418,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	}
 
 	executeSELECT( query:SPARQLQuery ):Promise<SPARQLClientResponse> {
-		let beforeTimestamp:number = ( new Date() ).valueOf();
+		let beforeTimestamp:number = (new Date()).valueOf();
 		return this.carbon.documents.executeRawSELECTQuery( query.endpoint, query.content ).then(
 			( [ result, response ]:[ SPARQL.RawResults.Class, HTTP.Response.Class ] ):SPARQLClientResponse => {
 				let duration:number = (new Date()).valueOf() - beforeTimestamp;
@@ -429,7 +430,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	}
 
 	executeDESCRIBE( query:SPARQLQuery ):Promise<SPARQLClientResponse> {
-		let beforeTimestamp:number = ( new Date() ).valueOf();
+		let beforeTimestamp:number = (new Date()).valueOf();
 		let requestOptions:HTTP.Request.Options = { headers: new Map().set( "Accept", new HTTP.Header.Class( query.format ) ) };
 		return this.carbon.documents.executeRawDESCRIBEQuery( query.endpoint, query.content, requestOptions ).then(
 			( [ result, response ]:[ string, HTTP.Response.Class ] ):SPARQLClientResponse => {
@@ -442,7 +443,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	}
 
 	executeCONSTRUCT( query:SPARQLQuery ):Promise<SPARQLClientResponse> {
-		let beforeTimestamp:number = ( new Date() ).valueOf();
+		let beforeTimestamp:number = (new Date()).valueOf();
 		let requestOptions:HTTP.Request.Options = { headers: new Map().set( "Accept", new HTTP.Header.Class( query.format ) ) };
 		return this.carbon.documents.executeRawCONSTRUCTQuery( query.endpoint, query.content, requestOptions ).then(
 			( [ result, response ]:[ string, HTTP.Response.Class ] ):SPARQLClientResponse => {
@@ -455,7 +456,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	}
 
 	executeASK( query:SPARQLQuery ):Promise<SPARQLClientResponse> {
-		let beforeTimestamp:number = ( new Date() ).valueOf();
+		let beforeTimestamp:number = (new Date()).valueOf();
 		return this.carbon.documents.executeRawASKQuery( query.endpoint, query.content ).then(
 			( [ result, response ]:[ SPARQL.RawResults.Class, HTTP.Response.Class ] ):SPARQLClientResponse => {
 				let duration:number = (new Date()).valueOf() - beforeTimestamp;
@@ -468,7 +469,7 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 
 	executeUPDATE( query:SPARQLQuery ):Promise<SPARQLClientResponse> {
 		this.isSending = true;
-		let beforeTimestamp:number = ( new Date() ).valueOf();
+		let beforeTimestamp:number = (new Date()).valueOf();
 		return this.carbon.documents.executeUPDATE( query.endpoint, query.content ).then(
 			( result:HTTP.Response.Class ):SPARQLClientResponse => {
 				let duration:number = (new Date()).valueOf() - beforeTimestamp;
@@ -480,15 +481,15 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	}
 
 	canExecute():boolean {
-		return ! ! (this.currentQuery.endpoint && this.currentQuery.type && this.currentQuery.content && this.currentQuery.operation && this.currentQuery.format);
+		return ! ! (this.currentQuery.type && this.currentQuery.content && this.currentQuery.operation && this.currentQuery.format);
 	}
 
 	canSaveQuery():boolean {
-		return ! ! (this.currentQuery.endpoint && this.currentQuery.type && this.currentQuery.content && this.currentQuery.operation && this.currentQuery.format && this.currentQuery.name);
+		return ! ! (this.currentQuery.type && this.currentQuery.content && this.currentQuery.operation && this.currentQuery.format && this.currentQuery.name);
 	}
 
 	canErase():boolean {
-		return ( ! ! this.endpoint || ! ! this.sparql);
+		return (! ! this.endpoint || ! ! this.sparql);
 	}
 
 	onEmptyStack():void {

--- a/src/app/root-content/sparql-client/sparql-client.component.ts
+++ b/src/app/root-content/sparql-client/sparql-client.component.ts
@@ -297,26 +297,31 @@ export class SPARQLClientComponent implements OnInit, AfterViewInit {
 	 * @returns      String. The name of the main SPARQL Query Operation.
 	 */
 	getSPARQLOperation( query:string ):string {
+
+		let queryForms:string[] = query.match( /\bCONSTRUCT\b|\bASK\b|\bSELECT\b|\bDESCRIBE\b|\bINSERT\b|\bDELETE\b|\bCLEAR\b|\bCREATE\b|\bDROP\b|\bLOAD\b/gi );
+
+		if( ! queryForms ) return null;
+
 		switch( true ) {
-			case (this.regExpConstruct.test( query )):
+			case (this.regExpConstruct.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.construct.name;
-			case (this.regExpAsk.test( query )):
+			case (this.regExpAsk.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.ask.name;
-			case (this.regExpSelect.test( query )):
+			case (this.regExpSelect.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.select.name;
-			case (this.regExpDescribe.test( query )):
+			case (this.regExpDescribe.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.describe.name;
-			case (this.regExpInsert.test( query )):
+			case (this.regExpInsert.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.insert.name;
-			case (this.regExpDelete.test( query )):
+			case (this.regExpDelete.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.delete.name;
-			case (this.regExpClear.test( query )):
+			case (this.regExpClear.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.clear.name;
-			case (this.regExpCreate.test( query )):
+			case (this.regExpCreate.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.create.name;
-			case (this.regExpDrop.test( query )):
+			case (this.regExpDrop.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.drop.name;
-			case (this.regExpLoad.test( query )):
+			case (this.regExpLoad.test( queryForms[ 0 ] )):
 				return this.sparqlQueryOperations.load.name;
 			default:
 				return null;


### PR DESCRIPTION
- Resolved #74 - Inverted success message on Documents and Access Points creation
- Resolved #72 - CONSTRUCT and SELECT combination serve wrong output formats of CONSTRUCTS
- Resolved #71 - The SPARQL client set disabled execute button on empty endpoint 