### PR TITLE
Bug/#93 - Property types dropdown empty

### DIFF
--- a/src/app/root-content/explorer/document-explorer/document-resource/document-resource.component.ts
+++ b/src/app/root-content/explorer/document-explorer/document-resource/document-resource.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, Input, Output, EventEmitter, AfterViewInit } from "@angular/core";
 
+import { CarbonLDP } from "carbonldp"
 import { RDFNode } from "carbonldp/RDF/Node"
 
 import { DocumentsResolverService } from "app/root-content/explorer/document-explorer/documents-resolver.service";
@@ -19,6 +20,7 @@ export class DocumentResourceComponent implements AfterViewInit {
 	element:ElementRef;
 	$element:JQuery;
 	documentsResolverService:DocumentsResolverService;
+	carbonldp:CarbonLDP;
 
 	modes:Modes = Modes;
 	properties:PropertyRow[] = [];
@@ -58,9 +60,10 @@ export class DocumentResourceComponent implements AfterViewInit {
 	@Output() onChanges:EventEmitter<RootRecords> = new EventEmitter<RootRecords>();
 
 
-	constructor( element:ElementRef, documentsResolverService:DocumentsResolverService ) {
+	constructor( element:ElementRef, documentsResolverService:DocumentsResolverService, carbonldp:CarbonLDP ) {
 		this.element = element;
 		this.documentsResolverService = documentsResolverService;
+		this.carbonldp = carbonldp;
 	}
 
 	ngAfterViewInit():void {
@@ -127,7 +130,7 @@ export class DocumentResourceComponent implements AfterViewInit {
 		let newProperty:PropertyRow = <PropertyRow>{
 			added: <Property>{
 				id: "",
-				name: "http://www.example.com#New Property " + numberOfProperty,
+				name: `${this.carbonldp.baseURI}vocabularies/main/#New Property ${numberOfProperty}`,
 				value: []
 			},
 			isBeingCreated: true,
@@ -165,7 +168,7 @@ export class DocumentResourceComponent implements AfterViewInit {
 				copy: {
 					id: propName,
 					name: propName,
-					value: typeof this.rootNode[ propName ] !== "undefined"? this.rootNode[ propName ] : []
+					value: typeof this.rootNode[ propName ] !== "undefined" ? this.rootNode[ propName ] : []
 				}
 			} );
 		} );

--- a/src/app/root-content/explorer/document-explorer/literals/literal.component.scss
+++ b/src/app/root-content/explorer/document-explorer/literals/literal.component.scss
@@ -1,17 +1,21 @@
 :host {
-	.dropdown {
-		.text .description {
-			display: none;
-		}
-		.item {
-			.title {
-				line-height: 1em;
-				font-size: 1.2em;
-				display: block;
+
+	.type {
+
+		/deep/ .dropdown.types {
+			.text .description {
+				display: none;
 			}
-			.description {
-				color: gray;
-				font-size: .8em;
+			.item {
+				.title {
+					line-height: 1em;
+					font-size: 1.2em;
+					display: block;
+				}
+				.description {
+					color: gray;
+					font-size: .8em;
+				}
 			}
 		}
 	}

--- a/src/app/root-content/explorer/document-explorer/literals/literal.component.ts
+++ b/src/app/root-content/explorer/document-explorer/literals/literal.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Input, Output, AfterViewChecked, EventEmitter, ViewChild, ChangeDetectorRef } from "@angular/core";
 
-import { XSD } from "carbonldp/Vocabularies";
+import { XSD } from "carbonldp/Vocabularies/XSD";
 import { forEachOwnProperty } from "carbonldp/Utils";
 import { URI } from "carbonldp/RDF/URI";
 
@@ -987,11 +987,11 @@ export class LiteralComponent implements AfterViewChecked {
 	private getXSDDataTypes():any[] {
 		let xsdDataTypes:any[] = [];
 		forEachOwnProperty( XSD, ( key:string, value:any ):void => {
-			if( URI.isAbsolute( key ) ) {
+			if( URI.isAbsolute( value ) && key !== "namespace" ) {
 				xsdDataTypes.push( {
-					title: value,
-					description: XSD[ value ],
-					value: XSD[ value ],
+					title: key,
+					description: XSD[ key ],
+					value: XSD[ key ],
 				} );
 			}
 		} );


### PR DESCRIPTION
- Resolved #93 - Property types dropdown empty
- Changed `http://example.com` to Carbon.baseURI +`vocabularies/main/` when creating new properties on a property name